### PR TITLE
Add `reaper-latest` to flake packages

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -103,11 +103,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1724748588,
-        "narHash": "sha256-NlpGA4+AIf1dKNq76ps90rxowlFXUsV9x7vK/mN37JM=",
+        "lastModified": 1726142289,
+        "narHash": "sha256-Jks8O42La+nm5AMTSq/PvM5O+fUAhIy0Ce1QYqLkyZ4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a6292e34000dc93d43bccf78338770c1c5ec8a99",
+        "rev": "280db3decab4cbeb22a4599bd472229ab74d25e1",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -91,16 +91,17 @@
                 inherit cargoArtifacts;
               });
             } // lib.optionalAttrs (system == "x86_64-linux") {
+              reaper-latest = (pkgs.reaper.overrideAttrs {
+                meta.license = "";
+                src = inputs.reaper;
+              });
               reaper-plugin-functions = pkgs.runCommand "reaper-plugin-functions"
                 {
                   buildInputs = with pkgs; [
                     xvfb-run
                     xdotool
                     which
-                    (reaper.overrideAttrs {
-                      meta.license = "";
-                      src = inputs.reaper;
-                    })
+                    self.packages.${system}.reaper-latest
                   ];
                 } ''
                 mkdir -p $out/include


### PR DESCRIPTION
Exports the x86_64-linux  version of Reaper for testing